### PR TITLE
default_template_class is deprecated in newer Mojolicious

### DIFF
--- a/lib/MojoX/Renderer/Xslate.pm
+++ b/lib/MojoX/Renderer/Xslate.pm
@@ -30,7 +30,7 @@ sub _init {
     if ($app) {
         $cache_dir = $app->home->rel_dir('tmp/compiled_templates');
         push @path, Mojo::Command->new->get_all_data(
-            $app->renderer->default_template_class,
+            $app->renderer->classes->[0],
         );
     }
     else {


### PR DESCRIPTION
Hi there,

great work on the Xslate renderer! I'm trying it out for a personal project, and as soon as I took it for a spin, Mojolicious let me know that:

```
Mojolicious::Renderer->default_template_class is DEPRECATED in favor of
Mojolicious::Renderer->classes!
```

So here's a patch that updates it properly and makes the warning go away. Hope you like it :-)

Cheers,

breno
