### PR TITLE
fix for Mojolicious v3.0

### DIFF
--- a/lib/MojoX/Renderer/Xslate.pm
+++ b/lib/MojoX/Renderer/Xslate.pm
@@ -5,7 +5,7 @@ use warnings;
 use parent qw(Mojo::Base);
 
 use File::Spec ();
-use Mojo::Command;
+use Mojo::Loader;
 use Text::Xslate ();
 use Try::Tiny;
 
@@ -29,7 +29,7 @@ sub _init {
 
     if ($app) {
         $cache_dir = $app->home->rel_dir('tmp/compiled_templates');
-        push @path, Mojo::Command->new->get_all_data(
+        push @path, Mojo::Loader->new->data(
             $app->renderer->classes->[0],
         );
     }

--- a/t/lite_app.t
+++ b/t/lite_app.t
@@ -15,7 +15,7 @@ my $xslate = MojoX::Renderer::Xslate->build(
     mojo             => app,
     template_options => {
         syntax => 'TTerse',
-        path   => [ Mojo::Command->new->get_all_data(__PACKAGE__) ],
+        path   => [ Mojo::Loader->new->data(__PACKAGE__) ],
     },
 );
 app->renderer->add_handler(tt => $xslate);


### PR DESCRIPTION
Hi. As you might have noticed, MojoX::Renderer::Xslate gets broken if we upgrade Mojolicious to version 3.0 as Mojolicious v3.0 has removed Mojo::Command and merged its get_all_data() into Mojo::Loader's data(). This is a fix for it.
