### PR TITLE
Test Xslate as default handler

### DIFF
--- a/lib/MojoX/Renderer/Xslate.pm
+++ b/lib/MojoX/Renderer/Xslate.pm
@@ -76,7 +76,9 @@ sub _render {
 
     if ($@) {
         $$output = undef;
-        if ( index( $@, 'Text::Xslate: LoadError: Cannot find \'exception.' ) < 0 ) {
+        if (    ( index( $@, 'Text::Xslate: LoadError: Cannot find \'exception.' ) < 0 )
+             && ( index( $@, 'Text::Xslate: LoadError: Cannot find \'not_found.' ) < 0 )
+        ) {
             die $@ unless $orig_err;
         }
     }

--- a/t/lite_app.t
+++ b/t/lite_app.t
@@ -23,7 +23,8 @@ app->renderer->add_handler(tt => $xslate);
 app->helper(die => sub { die 'died in helper' });
 
 get '/exception'    => 'error';
-get '/die'          => 'die';
+get '/die_tpl'      => 'die';
+get '/die_code'     => sub { die };
 get '/with_include' => 'include';
 get '/with_wrapper' => 'wrapper';
 get '/foo/:message' => 'index';
@@ -32,7 +33,29 @@ get '/on-disk'      => 'foo';
 my $t = Test::Mojo->new;
 
 $t->get_ok('/exception')->status_is(500)->content_like(qr/error|^$/i);
-$t->get_ok('/die')->status_is(500)->content_like(qr/error|^$/i);
+
+# will "die" inside Xslate execution
+$t->get_ok('/die_tpl')->status_is(500)->content_like(qr/error|^$/i);
+
+# dies before Xslate does anything and Xslate will not be used since 
+# internal mojo diagnostic templates are handled by default renderer
+# (i.e.: EP renderer) 
+$t->get_ok('/die_code')->status_is(500)->content_like(qr/error|^$/i);
+
+{
+    my $old_default = app->renderer->default_handler();
+    app->renderer->default_handler('tt');
+
+    $t->get_ok('/die_tpl')->status_is(500)->content_like(qr/error|^$/i);
+
+    # dies before Xslate does anything but then mojolicious wants to 
+    # render the (optional and here unavailable) exception template
+    # using Xslate engine which will not be able to locate that file
+    $t->get_ok('/die_code')->status_is(500)->content_like(qr/error|^$/i);
+
+    app->renderer->default_handler($old_default);
+}
+
 $t->get_ok('/foo/hello')->content_like(qr/^hello\s*$/);
 $t->get_ok('/with_include')->content_like(qr/^Hello\s*Include!Hallo\s*$/);
 $t->get_ok('/with_wrapper')->content_like(qr/^wrapped\s*$/);

--- a/t/lite_app.t
+++ b/t/lite_app.t
@@ -42,9 +42,17 @@ $t->get_ok('/die_tpl')->status_is(500)->content_like(qr/error|^$/i);
 # (i.e.: EP renderer) 
 $t->get_ok('/die_code')->status_is(500)->content_like(qr/error|^$/i);
 
+$t->get_ok('/foo/hello')->content_like(qr/^hello\s*$/);
+$t->get_ok('/with_include')->content_like(qr/^Hello\s*Include!Hallo\s*$/);
+$t->get_ok('/with_wrapper')->content_like(qr/^wrapped\s*$/);
+$t->get_ok('/on-disk')->content_is(4);
+$t->get_ok('/not_found')->status_is(404)->content_like(qr/not found/i);
+
 {
     my $old_default = app->renderer->default_handler();
     app->renderer->default_handler('tt');
+
+    $t->get_ok('/exception')->status_is(500)->content_like(qr/error|^$/i);
 
     $t->get_ok('/die_tpl')->status_is(500)->content_like(qr/error|^$/i);
 
@@ -53,14 +61,14 @@ $t->get_ok('/die_code')->status_is(500)->content_like(qr/error|^$/i);
     # using Xslate engine which will not be able to locate that file
     $t->get_ok('/die_code')->status_is(500)->content_like(qr/error|^$/i);
 
+    $t->get_ok('/foo/hello')->content_like(qr/^hello\s*$/);
+    $t->get_ok('/with_include')->content_like(qr/^Hello\s*Include!Hallo\s*$/);
+    $t->get_ok('/with_wrapper')->content_like(qr/^wrapped\s*$/);
+    $t->get_ok('/on-disk')->content_is(4);
+    $t->get_ok('/not_found')->status_is(404)->content_like(qr/not found/i);
+
     app->renderer->default_handler($old_default);
 }
-
-$t->get_ok('/foo/hello')->content_like(qr/^hello\s*$/);
-$t->get_ok('/with_include')->content_like(qr/^Hello\s*Include!Hallo\s*$/);
-$t->get_ok('/with_wrapper')->content_like(qr/^wrapped\s*$/);
-$t->get_ok('/on-disk')->content_is(4);
-$t->get_ok('/not_found')->status_is(404)->content_like(qr/not found/i);
 
 done_testing;
 


### PR DESCRIPTION
Additional and currently failing tests for when Xslate is set to be the default handler for the Mojolicious template renderer.

There are four cases to consider, I believe:

**EP handler as default and die() in Xslate template**

* In _render() $@ will be empty.
* Then the die() in the template will set the local $@ during rendering so we afterwards die().
* Mojolicious will the use the default renderer handler to process the exception and debug output templates.

This currently works as expected.

**EP handler as default and die() in app code**

The Xslate renderer handler will not be used in this case so this kind of works as expected.

**Xslate handler as default() and die() in app code**

* The Xslate renderer will not be called for the template itself but Mojolicious tries to render "exception.development.html.tx" and "exception.html.tx" - both of which by default do not exist by default.
* When trying to render these exception templates $@ in _render() is apparently already set to the message from the die() in the app code.
* Since the template files do not exist, Xslate will raise an exception.
* Nothing gets rendered and we immediately leave _render since the Xslate invocation dies.
* In the end Mojolicious will close the client connection after the internal inactivity timeout and the client receives no output.

The same problem would probably occur if the was some illegal xslate code in an existing "exception.development.html.tx" / "exception.html.tx".

**Xslate handler as default() and die() in a template**

Where the original exception happens does not matter; the behaviour of the server here will be the same as in the previous case.

I´m not exactly sure how the die_handler for Xslate, the (localized) $@, the return values from _render() and the exceptions raised in Xslate or _render() interact and haven´t yet been able to come up with code that handles all cases correctly.